### PR TITLE
Support for running on windows

### DIFF
--- a/Common/socket.h
+++ b/Common/socket.h
@@ -4,10 +4,15 @@
 #include <string>
 #include <unistd.h>
 #include <sys/types.h>
+#ifdef _WIN32
+#include <Winsock2.h>
+#include <windows.h>
+#else
 #include <sys/socket.h>
 #include <netinet/in.h>
-#include <iostream>
 #include <arpa/inet.h>
+#endif
+#include <iostream>
 
 using namespace std;
 


### PR DESCRIPTION
Added an if/else to the include statements to exclude mac-specific files that will not compile on windows machines and include windows equivalents of files. Functional on windows, not tested on macs.