### PR TITLE
Support for running on windows

### DIFF
--- a/Server-Project/server.h
+++ b/Server-Project/server.h
@@ -12,6 +12,9 @@
 #include <map>
 #include "../Common/socket.cpp"
 #include "../BingoGame/bingogame.h"
+#ifdef _WIN32
+#include <Ws2tcpip.h>
+#endif
 #include <pthread.h> 
 
 using namespace std;


### PR DESCRIPTION
Added an if statement to the include statements to include a specific windows file required to successfully build the file on windows machines.