### PR TITLE
Support for running on windows

### DIFF
--- a/Client-Project/client.h
+++ b/Client-Project/client.h
@@ -9,10 +9,16 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <sys/types.h>
+#ifdef _WIN32
+#include <Winsock2.h>
+#include <windows.h>
+#include <Ws2tcpip.h>
+#else
 #include <sys/socket.h>
 #include <netinet/in.h>
-#include <iostream>
 #include <arpa/inet.h>
+#endif
+#include <iostream>
 #include <iterator>
 #include <vector>
 #include <string.h> // std::strtok uses this library.


### PR DESCRIPTION
Added an if/else to the include statements to exclude mac-specific files that will not compile on windows machines and include windows equivalents of files. Functional on windows, not tested on macs.