### PR TITLE
Support for running on windows/linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 ﻿# CMakeList.txt : CMake project for Server-Project, include source and define
 # project specific logic here.
-cmake_minimum_required (VERSION 3.22)
+cmake_minimum_required (VERSION 3.20)
 
 # Set the project name.
 project ("Client-Server-Group-5-Project")
@@ -8,6 +8,7 @@ project ("Client-Server-Group-5-Project")
 # specify the C++ standard
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
+link_libraries(ws2_32 wsock32)
 
 # Add source to this project's executable.
 add_subdirectory ("Server-Project")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,9 @@ project ("Client-Server-Group-5-Project")
 # specify the C++ standard
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
-link_libraries(ws2_32 wsock32)
+IF (WIN32)
+    link_libraries(ws2_32 wsock32)
+ENDIF()
 
 # Add source to this project's executable.
 add_subdirectory ("Server-Project")


### PR DESCRIPTION
Lowered the CMake version requirement to allow the CS1 server to build project with CMake. Added a windows-specific library required to successfully build the project. Functional on windows, not tested on macs.