### PR TITLE
Support for running on windows/linux

### DIFF
--- a/Server-Project/CMakeLists.txt
+++ b/Server-Project/CMakeLists.txt
@@ -1,6 +1,6 @@
 ﻿# CMakeList.txt : CMake project for Server-Project, include source and define
 # project specific logic here.
-cmake_minimum_required (VERSION 3.22)
+cmake_minimum_required (VERSION 3.20)
 
 # Set the project name.
 project ("Server-Project" CXX)
@@ -11,6 +11,9 @@ enable_language(CXX)
 # specify the C++ standard
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
+IF (WIN32)
+    link_libraries(ws2_32 wsock32)
+ENDIF()
 
 # Add source to this project's executable.
 add_executable (Server "main.cpp")


### PR DESCRIPTION
Lowered the CMake version requirement to allow the CS1 server to build project with CMake. Added an if statement to add a windows-specific library required to successfully build the project for windows machines only.