### PR TITLE
Update comparison tests to expect boolean values

### DIFF
--- a/Test-Project/BingoGameTest.cpp
+++ b/Test-Project/BingoGameTest.cpp
@@ -12,8 +12,22 @@ namespace
         // Declares the variables your tests want to use.
 		BingoGame myBingoGame_;
     };
-
+    
     // When you have a test fixture, you define a test using TEST_F instead of TEST.
+    // Tests the default setTime method.
+    TEST_F(BingoGameTest, setTime)
+    {
+        string inputString = "5";
+        EXPECT_TRUE(myBingoGame_.setTime(inputString));
+    }
+
+    // Tests the default setMaxNum method.
+    TEST_F(BingoGameTest, setMaxNum)
+    {
+        string inputString = "50";
+        EXPECT_TRUE(myBingoGame_.setMaxNum(inputString));
+    }
+    
     // Tests the default setBoard method.
     TEST_F(BingoGameTest, setBoard) 
     {
@@ -28,17 +42,5 @@ namespace
         EXPECT_EQ(true, true);
     }
 
-    // Tests the default setTime method.
-    TEST_F(BingoGameTest, setTime) 
-    {
-        string inputString = "5";
-        EXPECT_TRUE(myBingoGame_.setTime(inputString));
-    }
 
-    // Tests the default setMaxNum method.
-    TEST_F(BingoGameTest, setMaxNum) 
-    {
-        string inputString = "50";
-        EXPECT_TRUE(myBingoGame_.setMaxNum(inputString));
-    }
 } // End of BingoGameTest

--- a/Test-Project/BingoGameTest.cpp
+++ b/Test-Project/BingoGameTest.cpp
@@ -31,6 +31,7 @@ namespace
     // Tests the default setBoard method.
     TEST_F(BingoGameTest, setBoard) 
     {
+	myBingoGame_.setMaxNum("50");
         string inputString = "1,2,3,4,5,8,7,9,19,14,12,13,15,11,35,32,23,24,25,26,28,39,37,46,50";
         EXPECT_TRUE(myBingoGame_.setBoard(inputString));
     }

--- a/Test-Project/BingoGameTest.cpp
+++ b/Test-Project/BingoGameTest.cpp
@@ -18,7 +18,7 @@ namespace
     TEST_F(BingoGameTest, setBoard) 
     {
         string inputString = "1,2,3,4,5,8,7,9,19,14,12,13,15,11,35,32,23,24,25,26,28,39,37,46,50";
-        EXPECT_EQ(myBingoGame_.setBoard(inputString), true);
+        EXPECT_TRUE(myBingoGame_.setBoard(inputString));
     }
 
     // Tests the default markBoard method.
@@ -32,13 +32,13 @@ namespace
     TEST_F(BingoGameTest, setTime) 
     {
         string inputString = "5";
-        EXPECT_EQ(myBingoGame_.setTime(inputString), true);
+        EXPECT_TRUE(myBingoGame_.setTime(inputString));
     }
 
     // Tests the default setMaxNum method.
     TEST_F(BingoGameTest, setMaxNum) 
     {
         string inputString = "50";
-        EXPECT_EQ(myBingoGame_.setMaxNum(inputString), true);
+        EXPECT_TRUE(myBingoGame_.setMaxNum(inputString));
     }
 } // End of BingoGameTest


### PR DESCRIPTION
Updated EXPECT_EQ to EXPECT_TRUE for boolean functions to possibly allow tests to pass for bingogame.h. Pull request for bingogame.h should be re-built/tested after BingoGameTest.cpp is updated to check if the update was successful (bingogame.h does not pass current tests). Logs show that bingogame.h was merged BEFORE BingoGameTest.cpp, and that may be the source of the build/test failing. Moved setMaxNum and setTime tests to before board related function tests that are dependent on setMaxNum. Set maxNum in the setBoard test to allow test to pass.